### PR TITLE
Issue #8141: Dash validator allowing None values in addition to floats

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -294,8 +294,9 @@ _str_err_msg = ('You must supply exactly {n} comma-separated values, you '
 
 
 class validate_nseq_float(object):
-    def __init__(self, n=None):
+    def __init__(self, n=None, allow_none=False):
         self.n = n
+        self.allow_none = allow_none
 
     def __call__(self, s):
         """return a seq of n floats or raise"""
@@ -309,7 +310,10 @@ class validate_nseq_float(object):
             raise ValueError(err_msg.format(n=self.n, num=len(s), s=s))
 
         try:
-            return [float(val) for val in s]
+            return [float(val)
+                    if not self.allow_none or val is not None
+                    else val
+                    for val in s]
         except ValueError:
             raise ValueError('Could not convert all entries to floats')
 
@@ -697,7 +701,7 @@ def validate_hatch(s):
         raise ValueError("Unknown hatch symbol(s): %s" % list(unknown))
     return s
 validate_hatchlist = _listify_validator(validate_hatch)
-validate_dashlist = _listify_validator(validate_nseq_float())
+validate_dashlist = _listify_validator(validate_nseq_float(allow_none=True))
 
 _prop_validators = {
         'color': _listify_validator(validate_color_for_prop_cycle,
@@ -963,9 +967,10 @@ defaultParams = {
     'lines.solid_joinstyle': ['round', validate_joinstyle],
     'lines.dash_capstyle':   ['butt', validate_capstyle],
     'lines.solid_capstyle':  ['projecting', validate_capstyle],
-    'lines.dashed_pattern':  [[3.7, 1.6], validate_nseq_float()],
-    'lines.dashdot_pattern': [[6.4, 1.6, 1, 1.6], validate_nseq_float()],
-    'lines.dotted_pattern':  [[1, 1.65], validate_nseq_float()],
+    'lines.dashed_pattern':  [[3.7, 1.6], validate_nseq_float(allow_none=True)],
+    'lines.dashdot_pattern': [[6.4, 1.6, 1, 1.6],
+                              validate_nseq_float(allow_none=True)],
+    'lines.dotted_pattern':  [[1, 1.65], validate_nseq_float(allow_none=True)],
     'lines.scale_dashes':  [True, validate_bool],
 
     # marker props

--- a/lib/matplotlib/tests/test_cycles.py
+++ b/lib/matplotlib/tests/test_cycles.py
@@ -161,7 +161,7 @@ def test_valid_input_forms():
     ax.set_prop_cycle('color', np.array([[1, 0, 0],
                                          [0, 1, 0],
                                          [0, 0, 1]]))
-    ax.set_prop_cycle('dashes', [[], [13, 2], [8, 3, 1, 3]])
+    ax.set_prop_cycle('dashes', [[], [13, 2], [8, 3, 1, 3], [None, None]])
     ax.set_prop_cycle(lw=[1, 2], color=['k', 'w'], ls=['-', '--'])
     ax.set_prop_cycle(lw=np.array([1, 2]),
                       color=np.array(['k', 'w']),


### PR DESCRIPTION
Validators for dashed linestyles now allow `None` as an allowed value along with floats if optional `allow_none` kwarg flag in `validate_nseq_float`.

Other validators that use `validate_nseq_float` aren't affected, so this bugfix won't have any breaking changes.